### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libnghttp2-green.svg)](https://anaconda.org/conda-forge/libnghttp2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libnghttp2.svg)](https://anaconda.org/conda-forge/libnghttp2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libnghttp2.svg)](https://anaconda.org/conda-forge/libnghttp2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libnghttp2.svg)](https://anaconda.org/conda-forge/libnghttp2) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libnghttp2--static-green.svg)](https://anaconda.org/conda-forge/libnghttp2-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libnghttp2-static.svg)](https://anaconda.org/conda-forge/libnghttp2-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libnghttp2-static.svg)](https://anaconda.org/conda-forge/libnghttp2-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libnghttp2-static.svg)](https://anaconda.org/conda-forge/libnghttp2-static) |
 
 Installing nghttp2
 ==================
@@ -106,10 +107,10 @@ Installing `nghttp2` from the `conda-forge` channel can be achieved by adding `c
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `libnghttp2` can be installed with:
+Once the `conda-forge` channel has been enabled, `libnghttp2, libnghttp2-static` can be installed with:
 
 ```
-conda install libnghttp2
+conda install libnghttp2 libnghttp2-static
 ```
 
 It is possible to list all of the versions of `libnghttp2` available on your platform with:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,3 +6,4 @@ cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install
+rm ${PREFIX}/lib/libnghttp2.a

--- a/recipe/build_static.sh
+++ b/recipe/build_static.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp lib/.libs/libnghttp2.a ${PREFIX}/lib/libnghttp2.a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: eacc6f0f8543583ecd659faf0a3f906ed03826f1d4157b536b4b385fe47c5bb8
 
 build:
-  number: 1
+  number: 2
   skip: true  # [not unix]
 
 requirements:
@@ -59,7 +59,15 @@ outputs:
       - lib/pkgconfig/libnghttp2*  # [unix]
       - bin/nghttp*  # [unix]
     test:
-      commands: nghttp -nv https://nghttp2.org
+      commands:
+        - nghttp -nv https://nghttp2.org
+        - test -f ${PREFIX}/lib/libnghttp2.14${SHLIB_EXT}  # [unix]
+        - test ! -f ${PREFIX}/lib/libnghttp2.a  # [unix]
+  - name: libnghttp2-static
+    script: build_static.sh  # [unix]
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libnghttp2.a  # [unix]
 
 about:
   home: http://github.com/nghttp2/nghttp2


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
